### PR TITLE
Bug in network setup when not using IPv6

### DIFF
--- a/backend/functions-networking.sh
+++ b/backend/functions-networking.sh
@@ -386,7 +386,7 @@ enable_manual_nic()
   # Set static IPv6 address
   get_value_from_cfg netIPv6
   NETIP="${VAL}"
-  if [ -n ${NETIP} ]
+  if [ -n "${NETIP}" ]
   then
       rc_halt "ifconfig inet6 ${NIC} ${NETIP} -ifdisabled up"
   fi


### PR DESCRIPTION
The lack of quotes around ```${NETIP}``` on line 389 caused the conditional to become ```if [ -n ]``` if ```NETIP``` was empty so the conditional would always evaluate to true so pc-sysinstall would crash if no IPv6 settings were specified. 