### PR TITLE
Update functions-unmount.sh

### DIFF
--- a/backend/functions-unmount.sh
+++ b/backend/functions-unmount.sh
@@ -364,7 +364,11 @@ setup_efi_boot()
 
     # Create the new EFI entry
     rc_halt "efibootmgr -c -l $EFIFILE -L $EFILABEL"
-
+    #Try to activate this new entry
+    EFINUM=$(efibootmgr | grep $EFILABEL | awk '{print $1}' | sed 's|+||g' | sed 's|*||g')
+    if [ -n "$EFINUM" ] ; then
+      rc_nohalt "efibootmgr -a -b $EFINUM"
+    fi
     # Cleanup
     rc_halt "umount ${FSMNT}/boot/efi"
   done


### PR DESCRIPTION
Add an attempt to activate the new EFI boot entry. Will not fail the installation if this activation fails.
Note that this is done *AFTER* the boot entry is created - so we should not have a repeat of the activation errors discovered on systems such as VMWare instances.