### PR TITLE
Add another failover option in case efibootmgr does not register next…

### DIFF
--- a/backend/functions-unmount.sh
+++ b/backend/functions-unmount.sh
@@ -368,7 +368,11 @@ setup_efi_boot()
     EFINUM=$(efibootmgr | grep $EFILABEL | awk '{print $1}' | sed 's|+||g' | sed 's|*||g')
     if [ -n "$EFINUM" ] ; then
       rc_nohalt "efibootmgr -a $EFINUM" #activate it
-      rc_nohalt "efibootmgr -n $EFINUM" #Set is as the next boot default
+      rc_nohalt "efibootmgr -n $EFINUM" #Set it as the next boot default
+    fi
+    # Now ensure the fallback location for the EFI boot partition exists, and make it if needed
+    if [ ! -e "${FSMNT}/boot/efi/EFI/BOOT/BOOTX64.EFI" ] ; then
+      cp "${EFIFILE}" "${FSMNT}/boot/efi/EFI/BOOT/BOOTX64.EFI"
     fi
     # Cleanup
     rc_halt "umount ${FSMNT}/boot/efi"


### PR DESCRIPTION
… bootvar properly.

If the default file location (bootx64.efi) does not exist, copy the efi file over to that location as well. Do not use efibootmgr to try and register that - it is just the default location that EFI looks if no boot registrations are found.