### PR TITLE
Moving EFI part side to 260MB to match freenas and fix install bug

### DIFF
--- a/backend/functions-bsdlabel.sh
+++ b/backend/functions-bsdlabel.sh
@@ -324,9 +324,9 @@ get_autosize()
   # Pad the size a bit
   _aSize=`expr $_aSize - 5`
 
-  # If installing to UEFI, save 100MB for UEFI partition
+  # If installing to UEFI, save 260MB for UEFI partition
   if [ "$BOOTMODE" = "UEFI" ]; then
-    _aSize=`expr $_aSize - 100`
+    _aSize=`expr $_aSize - 260`
   fi
 
   VAL="$_aSize"

--- a/backend/functions-disk.sh
+++ b/backend/functions-disk.sh
@@ -780,7 +780,7 @@ init_gpt_full_disk()
   # Check the boot mode we are using {pc|efi}
   if [ "$BOOTMODE" = "UEFI" ]; then
     # Need to enable EFI booting, lets add the partition
-    rc_halt "gpart add -a 4k -s 100M -t efi ${_intDISK}"
+    rc_halt "gpart add -a 4k -s 260M -t efi ${_intDISK}"
     rc_halt "newfs_msdos -F 16 ${_intDISK}p1"
     if [ -z "${EFI_POST_SETUP}" ] ; then
       EFI_POST_SETUP="${_intDISK}"


### PR DESCRIPTION
Below is commit message when same was done in freenas for reference

commit 6a9324bbe9c72350d23ac21ae694b4c877e7dd50
Author: Alexander Motin <mav@FreeBSD.org>
Date: Fri Aug 4 12:59:21 2017 +0300

260MB is the minimal FAT32 size on 4Kn disks, and the size used by Microsoft
even on disks with 512 byte sectors. While at this moment we use FAT16, this
change could be unnecessary to support 4Kn disks, but there seem to be a bug
in newfs_msdosfs cluster size choosing logic, failing the FS creation.

This change should make us more future-proof, while slightly increase boot
disk size requirements and possibly cause some issues with adding new disks
of the same size into old boot pool, since now data partition is slightly
smaller. It is probably better to bump it now while UEFI is less spread.

Ticket: TOS-319